### PR TITLE
Added exception handling in case of a corrupted database exfiltrated.

### DIFF
--- a/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
+++ b/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
@@ -227,6 +227,8 @@ namespace ChloniumUI
             SQLiteCommand cmd = new SQLiteCommand("DELETE FROM cookies;", con);
             cmd.ExecuteNonQuery();
 
+            int exceptionsCount = 0;
+
             foreach (Cookie c in items)
             {
                 cmd = new SQLiteCommand("INSERT INTO cookies (creation_utc, host_key, name, value, " +
@@ -257,7 +259,11 @@ namespace ChloniumUI
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(ex.Message);
+                    if (exceptionsCount < 3)
+                    {
+                        MessageBox.Show(ex.Message);
+                        exceptionsCount++;
+                    }
                 }
             }
         }
@@ -271,6 +277,8 @@ namespace ChloniumUI
             con.Open();
             SQLiteCommand cmd = new SQLiteCommand("DELETE FROM logins;", con);
             cmd.ExecuteNonQuery();
+
+            int exceptionsCount = 0;
 
             foreach (Login c in items)
             {
@@ -314,7 +322,11 @@ namespace ChloniumUI
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(ex.Message);
+                    if (exceptionsCount < 3)
+                    {
+                        MessageBox.Show(ex.Message);
+                        exceptionsCount++;
+                    }
                 }
             }
         }
@@ -337,6 +349,8 @@ namespace ChloniumUI
 
             var cmd = new SQLiteCommand(stm, con);
             SQLiteDataReader reader = cmd.ExecuteReader();
+
+            int exceptionsCount = 0;
 
             if (reader.HasRows)
             {
@@ -373,7 +387,11 @@ namespace ChloniumUI
                         }
                         catch (Exception e)
                         {
-                            MessageBox.Show(e.Message);
+                            if (exceptionsCount < 3)
+                            {
+                                MessageBox.Show(e.Message);
+                                exceptionsCount++;
+                            }
                             continue;
                         }
                     }
@@ -436,6 +454,8 @@ namespace ChloniumUI
             var cmd = new SQLiteCommand(stm, con);
             SQLiteDataReader reader = cmd.ExecuteReader();
 
+            int exceptionsCount = 0;
+
             if (reader.HasRows)
             {
                 bool ret = true;
@@ -471,7 +491,11 @@ namespace ChloniumUI
                         }
                         catch (Exception e)
                         {
-                            MessageBox.Show(e.Message);
+                            if (exceptionsCount < 3)
+                            {
+                                MessageBox.Show(e.Message);
+                                exceptionsCount++;
+                            }
                             continue;
                         }
                     }

--- a/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
+++ b/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
@@ -95,6 +95,7 @@ namespace ChloniumUI
 
             string backupFile;
             List<Item> items = new List<Item>();
+            int count = 0;
 
             switch (dbType)
             {
@@ -109,6 +110,7 @@ namespace ChloniumUI
                     {
                         c.encrypted_value = crypto.Encrypt(c.decrypted_value);
                     }
+                    count = items.Count();
                     ImportCookies(items);
                     break;
                 case "logins":
@@ -123,12 +125,13 @@ namespace ChloniumUI
                     {
                         i.password_value = crypto.Encrypt(i.decrypted_password_value);
                     }
+                    count = items.Count();
                     ImportLogins(items);
                     break;
                 default:
                     return;
             }
-            MessageBox.Show("Imported!");
+            MessageBox.Show($"Imported {count} {dbType}!");
         }
 
         private void File_Click(object sender, RoutedEventArgs e)
@@ -359,9 +362,11 @@ namespace ChloniumUI
 
                 while (ret)
                 {
+                    byte[] encrypted_value;
                     try
                     {
                         ret = reader.Read();
+                        encrypted_value = (byte[])reader["encrypted_value"];
                     }
                     catch (Exception e)
                     {
@@ -376,7 +381,6 @@ namespace ChloniumUI
                         continue;
                     }
 
-                    byte[] encrypted_value = (byte[])reader["encrypted_value"];
                     byte[] decrypted_value = null;
 
                     if (encrypted_value[0] == 'v' && encrypted_value[1] == '1' && encrypted_value[2] == '0')
@@ -435,6 +439,11 @@ namespace ChloniumUI
             catch (Exception e)
             { }
 
+            if(items.Count() == 0)
+            {
+                MessageBox.Show("No cookies were exported from specified input database!", "Error");
+            }
+
             return items;
         }
 
@@ -463,9 +472,11 @@ namespace ChloniumUI
 
                 while (ret)
                 {
+                    byte[] encrypted_value;
                     try
                     {
                         ret = reader.Read();
+                        encrypted_value = (byte[])reader["password_value"];
                     }
                     catch (Exception e)
                     {
@@ -480,7 +491,6 @@ namespace ChloniumUI
                         continue;
                     }
                     
-                    byte[] encrypted_value = (byte[])reader["password_value"];
                     byte[] decrypted_value = null;
 
                     if (encrypted_value[0] == 'v' && encrypted_value[1] == '1' && encrypted_value[2] == '0')
@@ -542,6 +552,12 @@ namespace ChloniumUI
                 Console.WriteLine("No rows found.");
             }
             reader.Close();
+
+            if(items.Count() == 0)
+            {
+                MessageBox.Show("No logins were exported from specified input database!", "Error");
+            }
+
             return items;
         }
 

--- a/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
+++ b/ChloniumUI/ChloniumUI/MainWindow.xaml.cs
@@ -340,8 +340,28 @@ namespace ChloniumUI
 
             if (reader.HasRows)
             {
-                while (reader.Read())
+                bool ret = true;
+                int errCount = 0;
+
+                while (ret)
                 {
+                    try
+                    {
+                        ret = reader.Read();
+                    }
+                    catch (Exception e)
+                    {
+                        errCount++;
+
+                        if (errCount > 3)
+                        {
+                            MessageBox.Show("Some cookies could not be imported.", "Warning");
+                            break;
+                        }
+
+                        continue;
+                    }
+
                     byte[] encrypted_value = (byte[])reader["encrypted_value"];
                     byte[] decrypted_value = null;
 
@@ -389,7 +409,14 @@ namespace ChloniumUI
             {
                 Console.WriteLine("No rows found.");
             }
-            reader.Close();
+
+            try
+            {
+                reader.Close();
+            }
+            catch (Exception e)
+            { }
+
             return items;
         }
 
@@ -411,8 +438,28 @@ namespace ChloniumUI
 
             if (reader.HasRows)
             {
-                while (reader.Read())
+                bool ret = true;
+                int errCount = 0;
+
+                while (ret)
                 {
+                    try
+                    {
+                        ret = reader.Read();
+                    }
+                    catch (Exception e)
+                    {
+                        errCount++;
+
+                        if (errCount > 3)
+                        {
+                            MessageBox.Show("Some logins could not be imported.", "Warning");
+                            break;
+                        }
+
+                        continue;
+                    }
+                    
                     byte[] encrypted_value = (byte[])reader["password_value"];
                     byte[] decrypted_value = null;
 


### PR DESCRIPTION
In case we have exfiltrated Cookies/Logins database out from the in-use Chrome browser, the database will not be properly compacted and flushed. We can attempt to fix the database using existing SQLite browsers and then re-import the database in Chlonium.

However that sometimes may be trickier as it sounds, so the easier approach would be to just surround sqlite rows reading logic within try...catch statement and handle everything that reader has to throw away.

Thanks to this PR chlonium was able to import cookies I was dealing with during my recent engagement.

Cheers,
Mariusz.